### PR TITLE
(fix) Renamed open function for login so it doesn't conflict with rec…

### DIFF
--- a/client/app/directives/login/login.js
+++ b/client/app/directives/login/login.js
@@ -2,7 +2,7 @@ angular.module('recipes')
   .directive('login', [function() {
     return {
       restrict: 'EA',
-      template: '<a href="#" ng-click="open()">Login</a>',
+      template: '<a href="#" ng-click="openLogin()">Login</a>',
       controller: 'LoginDirectiveCtrl'
     };
   }])
@@ -15,7 +15,7 @@ angular.module('recipes')
   }])
   .controller('LoginDirectiveCtrl', ['$scope', '$rootScope', '$uibModal', 'Auth', function($scope, $rootScope, $uibModal, Auth) {
 
-    $scope.open = function() {
+    $scope.openLogin = function() {
       $rootScope.search = false;
       var modalInstance = $uibModal.open({
         animation: $scope.animationsEnabled,


### PR DESCRIPTION
…ipe modals.

When you click on a recipe, it would open up the login because the functions had the same name.  Changed name to resolve conflict.
